### PR TITLE
README: Clarify POSIX standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Potato Make is a scheme library that aims to simplify the task of
 maintaining, updating, and regenerating programs.  It is inspired by
-the `make` utility in POSIX.  With this library, you can write a
+the `make` utility in IEEE Std 1003.1-2017 (POSIX).  With this library, you can write a
 build script in Guile Scheme.
 
 ## Boilerplate


### PR DESCRIPTION
The term "POSIX" is an abbreviation referring to multiple IEEE standard versions, this is clarifying to use the latest one.