### PR TITLE
potato/make: Attempt at better wording for success

### DIFF
--- a/potato/make.scm
+++ b/potato/make.scm
@@ -285,7 +285,7 @@ targets listed on the parsed command-line are used."
             #f)
           ;; else
           (begin
-            (print "The recipe for “~A” has succeeded.~%" target)
+            (print "The recipe “~A” finished successfully.~%" target)
             (if (not (null? rest))
                 (loop (car rest) (cdr rest))
 


### PR DESCRIPTION
Currently there is just a difference of one word in-between fail/success state, this attempts to differenciate them to make the output easier to read for complicated recipes.